### PR TITLE
Use -O3 -g0 only when CFLAGS is not defined in env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-CFLAGS+=-O3
-CFLAGS+=-g0
+CFLAGS?=-O3 -g0
 
 SCM_REV:=-D'SCM_REV="$(shell git rev-parse HEAD 2> /dev/null || echo 0)"'
 SCM_BRANCH=-D'SCM_BRANCH="$(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo unknown)"'


### PR DESCRIPTION
Hi,

The current Makefile hardcoded -O3 and -g0 which will strip debug symbols and causing some trouble in some packaging system.

Suggest to follow CFLAGS in the environment if it is defined by the build system.

Regards,
Hon-Ming