### PR TITLE
Update resolution fix

### DIFF
--- a/include/lib_common/PixMapBuffer.h
+++ b/include/lib_common/PixMapBuffer.h
@@ -126,6 +126,17 @@ AL_TDimension AL_PixMapBuffer_GetDimension(AL_TBuffer const* pBuf);
 bool AL_PixMapBuffer_SetDimension(AL_TBuffer* pBuf, AL_TDimension tDim);
 
 /*************************************************************************//*!
+   \brief Update the dimension of the frame stored in the AL_TBuffer and all meta data
+   \param[in] pBuf Pointer to the AL_TBuffer
+   \param[in] tDim The new dimension
+   \param[in] chunkIdx Buffer chunk id 
+   \param[in] pPlDescriptions Pointer to a list a planes description
+   \param[in] iNbPlanes Number of planes of the list
+   \return Returns true if dimension was correctly set, false otherwise
+*****************************************************************************/
+bool AL_PixMapBuffer_UpdateDimension(AL_TBuffer* pBuf, AL_TDimension tDim, int chunkIdx, const AL_TPlaneDescription* pPlDescriptions, int iNbPlanes);
+
+/*************************************************************************//*!
    \brief Get the FourCC of the frame stored in the AL_TBuffer
    \param[in] pBuf Pointer to the AL_TBuffer
    \return Returns the FourCC of the frame if successful, 0 otherwise

--- a/lib_common/PixMapBuffer.c
+++ b/lib_common/PixMapBuffer.c
@@ -173,6 +173,18 @@ bool AL_PixMapBuffer_SetDimension(AL_TBuffer* pBuf, AL_TDimension tDim)
   return true;
 }
 
+bool AL_PixMapBuffer_UpdateDimension(AL_TBuffer* pBuf, AL_TDimension tDim, int chunkIdx, const AL_TPlaneDescription* pPlDescriptions, int iNbPlanes)
+{
+  AL_TPixMapMetaData* pMeta = (AL_TPixMapMetaData*)AL_Buffer_GetMetaData(pBuf, AL_META_TYPE_PIXMAP);
+
+  if(pMeta == NULL)
+    return false;
+
+  AddPlanesToMeta(pMeta, chunkIdx, pPlDescriptions, iNbPlanes);
+
+  return AL_PixMapBuffer_SetDimension(pBuf, tDim);
+}
+
 TFourCC AL_PixMapBuffer_GetFourCC(AL_TBuffer const* pBuf)
 {
   AL_TPixMapMetaData* pMeta = (AL_TPixMapMetaData*)AL_Buffer_GetMetaData(pBuf, AL_META_TYPE_PIXMAP);

--- a/lib_encode/Com_Encoder.c
+++ b/lib_encode/Com_Encoder.c
@@ -1210,6 +1210,8 @@ static bool AL_Common_Encoder_SetChannelResolution(AL_TLayerCtx* pLayerCtx, AL_T
     return false;
   pChanParam->uEncWidth = tDim.iWidth;
   pChanParam->uEncHeight = tDim.iHeight;
+  pChanParam->uSrcWidth = tDim.iWidth;
+  pChanParam->uSrcHeight = tDim.iHeight;
   return true;
 }
 


### PR DESCRIPTION
Hello, we use the VCU quite heavily in our application and find it very useful for the overall performance of our system. 

We were trying to use the dynamic resolution updating in our custom app, but it seems some parameters in the channel parameters struct for the encoder were missing a reassignment in `Com_Encoder.c`. 

I also added a method that would update the metadata of the `PixMapBuffer` of that buffer in one API call. 